### PR TITLE
Corrige bug de rename em partições diferentes

### DIFF
--- a/extractors.py
+++ b/extractors.py
@@ -2,7 +2,7 @@ import csv
 import re
 from functools import lru_cache
 from io import StringIO, TextIOWrapper
-from os import rename as rename_file
+from shutil import move as move_file
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -115,7 +115,7 @@ class Extractor:
 
         url = self.url(year)
         file_data = download_file(url, progress=True)
-        rename_file(file_data.uri, filename)
+        move_file(file_data.uri, filename)
         return {"downloaded": True, "filename": filename}
 
     def extract_state_from_filename(self, filename):


### PR DESCRIPTION
Ao executar `python tse.py votacao-zona` eu recebi:

```
VotacaoZona 1996
Downloading file: 100%|███████████████████████████████████████████████████████████████████████████████████████| 2.36M/2.36M [00:02<00:00, 1.01Mbytes/s]
  Downloading...Traceback (most recent call last):
  File "tse.py", line 155, in <module>
    download_only=args.download_only,
  File "tse.py", line 30, in extract_data
    result = extractor.download(year, force=force_redownload)
  File "/home/meu_usuario/repos/eleicoes-brasil/extractors.py", line 118, in download
    rename_file(file_data.uri, filename)
OSError: [Errno 18] Invalid cross-device link: '/tmp/tmps9dp5bld.zip' -> '/home/meu_usuario/repos/eleicoes-brasil/data/download/votacao-zona-1996.zip'
```

Após uma breve busca, li relatos de que o `os.rename` não lida bem com movimentação entre partições diferentes. Eu tenho o `/` em uma partição e o `/home` em outra.

Fiz essa correção e funcionou aqui. Será que atende bem para outros também? Vi que ainda não comitou os testes, por isso não rodei.
