### PR TITLE
Topic/candidatura 2020

### DIFF
--- a/extractors.py
+++ b/extractors.py
@@ -70,6 +70,11 @@ else:
     FINAL_VOTATION_YEAR = NOW.year
 
 
+class SimNaoBooleanField(rows.fields.BoolField):
+    TRUE_VALUES = ("sim",)
+    FALSE_VALUES = ("não", "nao")
+
+
 @lru_cache()
 def read_header(filename, encoding="utf-8"):
     filename = Path(filename)
@@ -333,6 +338,9 @@ class CandidaturaExtractor(Extractor):
             new["titulo_eleitoral"] = fix_titulo_eleitoral(new["titulo_eleitoral"])
             new["codigo_cargo"], new["descricao_cargo"], new["pergunta"] = fix_cargo(
                 new["codigo_cargo"], new["descricao_cargo"]
+            )
+            new["candidato_inserido_urna"] = SimNaoBooleanField.deserialize(
+                new["candidato_inserido_urna"]
             )
             new["data_eleicao"] = fix_data(new["data_eleicao"])
             new["data_nascimento"] = fix_data(new["data_nascimento"])

--- a/extractors.py
+++ b/extractors.py
@@ -250,7 +250,7 @@ class Extractor:
 
 class CandidaturaExtractor(Extractor):
 
-    year_range = tuple(range(1996, FINAL_VOTATION_YEAR, 2))
+    year_range = tuple(range(1996, FINAL_VOTATION_YEAR + 1, 2))
     schema_filename = settings.SCHEMA_PATH / "candidatura.csv"
 
     def url(self, year):
@@ -261,7 +261,11 @@ class CandidaturaExtractor(Extractor):
 
     def valid_filename(self, filename):
         name = filename.lower()
-        return name.startswith("consulta_cand_") and "_brasil.csv" not in name
+        return (
+            name.startswith("consulta_cand_")
+            and "_brasil.csv" not in name
+            and not name.endswith("todos.csv")
+        )
 
     def fix_fobj(self, fobj):
         """Fix wrong-escaped lines from the TSE's CSVs
@@ -291,6 +295,8 @@ class CandidaturaExtractor(Extractor):
             header_year = "2012"
         elif 2014 <= year <= 2018:
             header_year = "2018"
+        elif year == 2020:
+            header_year = "2020"
         else:
             raise ValueError(f"Unrecognized year ({year}, {uf})")
         return {

--- a/headers/candidatura-2020.csv
+++ b/headers/candidatura-2020.csv
@@ -1,0 +1,64 @@
+nome_tse,nome_final,descricao
+DT_GERACAO,,Data de geração do arquivo (data da extração dos dados)
+HH_GERACAO,,Hora de geração do arquivo (hora da extração) - Horário de Brasília
+ANO_ELEICAO,ano_eleicao,Ano da eleição (referente ao ano eleitoral de pesquisa)
+CD_TIPO_ELEICAO,codigo_tipo_eleicao,Código do tipo de eleição
+NM_TIPO_ELEICAO,nome_tipo_eleicao,Nome do tipo de eleição
+NR_TURNO,numero_turno,Número do turno da eleição
+CD_ELEICAO,codigo_eleicao,Código da eleição
+DS_ELEICAO,descricao_eleicao,Descrição da eleição
+DT_ELEICAO,data_eleicao,Data em que ocorreu a eleição
+TP_ABRANGENCIA,tipo_abrangencia_eleicao,Tipo de abrangência da eleição
+SG_UF,sigla_uf,Sigla da Unidade da Federação em que ocorreu a eleição
+SG_UE,sigla_ue,Sigla da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município)
+NM_UE,descricao_ue,Nome da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município)
+CD_CARGO,codigo_cargo,Código do cargo ao qual o candidato concorre
+DS_CARGO,descricao_cargo,Descrição do cargo ao qual o candidato concorre
+SQ_CANDIDATO,numero_sequencial,Número sequencial do candidato gerado internamente pelos sistemas eleitorais (não é o número da campanha do candidato)
+NR_CANDIDATO,numero_urna,Nümero do candidato na urna
+NM_CANDIDATO,nome,Nome completo do candidato
+NM_URNA_CANDIDATO,nome_urna,Nome de urna do candidato
+NM_SOCIAL_CANDIDATO,nome_social,Nome social do candidato
+NR_CPF_CANDIDATO,cpf,Número do CPF do candidato
+NM_EMAIL,email,Endereço de e-mail do candidato
+CD_SITUACAO_CANDIDATURA,codigo_situacao_candidatura,Código da situação do registro de candidatura do candidato
+DS_SITUACAO_CANDIDATURA,descricao_situacao_candidatura,"Descrição da situação do registro de candidatura do candidato - pode assumir os valores “apto (apto para ir para urna)”, “inapto” (inapto para ir para urna) e “cadastrado” (registro de candidatura realizado, mas ainda não julgado)"
+CD_DETALHE_SITUACAO_CAND,codigo_detalhe_situacao_candidatura,Código do detalhe da situação do registro de candidatura do candidato
+DS_DETALHE_SITUACAO_CAND,descricao_detalhe_situacao_candidatura,Descrição do detalhe da situação do registro de candidatura do candidato
+TP_AGREMIACAO,tipo_agremiacao,Tipo de agremiação - pode assumir os valores “coligação” (quando o candidato concorre por coligação) e “partido isolado” (quando o candidato concorre somente pelo partido)
+NR_PARTIDO,numero_partido,Número do partido do candidato
+SG_PARTIDO,sigla_partido,Sigla do partido do candidato
+NM_PARTIDO,nome_partido,Nome do partido do candidato
+SQ_COLIGACAO,codigo_legenda,Número sequencial da coligação da qual o candidato pertence
+NM_COLIGACAO,nome_legenda,Nome da coligação da qual o candidato pertence
+DS_COMPOSICAO_COLIGACAO,composicao_legenda,Descrição da composição da coligação da qual o candidato pertence
+CD_NACIONALIDADE,codigo_nacionalidade,Código da nacionalidade do candidato
+DS_NACIONALIDADE,descricao_nacionalidade,Descrição da nacionalidade do candidato
+SG_UF_NASCIMENTO,sigla_uf_nascimento,Sigla da UF de nascimento do candidato
+CD_MUNICIPIO_NASCIMENTO,codigo_municipio_nascimento,Código TSE do município de nascimento do candidato
+NM_MUNICIPIO_NASCIMENTO,nome_municipio_nascimento,Nome do município de nascimento do candidato
+DT_NASCIMENTO,data_nascimento,Data de nascimento do candidato
+NR_IDADE_DATA_POSSE,idade_data_posse,Idade do candidato na data da posse (consultar a data de posse para cada cargo e unidade eleitoral nos arquivos de vagas)
+NR_TITULO_ELEITORAL_CANDIDATO,titulo_eleitoral,Número do título eleitoral do candidato
+CD_GENERO,codigo_genero,Código do gênero do candidato
+DS_GENERO,descricao_genero,Descrição do gênero do candidato
+CD_GRAU_INSTRUCAO,codigo_grau_instrucao,Código do grau de instrução do candidato
+DS_GRAU_INSTRUCAO,descricao_grau_instrucao,Descrição do grau de instrução do candidato
+CD_ESTADO_CIVIL,codigo_estado_civil,Código do estado civil do candidato
+DS_ESTADO_CIVIL,descricao_estado_civil,Descrição do estado civil do candidato
+CD_COR_RACA,codigo_cor_raca,Código da cor/raça do candidato (auto declaração)
+DS_COR_RACA,descricao_cor_raca,Descrição da cor/raça do candidato (auto declaração)
+CD_OCUPACAO,codigo_ocupacao,Código da ocupação do candidato
+DS_OCUPACAO,descricao_ocupacao,Descrição da ocupação do candidato
+VR_DESPESA_MAX_CAMPANHA,despesa_maxima_campanha,"Despesa máxima de campanha declarada pelo partido para aquele cargo, em reais - os valores máximos para candidatos a vice e suplentes serão incluídos nos valores indicados para os titulares (quando não informado o valor será -1)"
+CD_SIT_TOT_TURNO,codigo_totalizacao_turno,Código da situação de totalização do candidato naquele turno
+DS_SIT_TOT_TURNO,descricao_totalizacao_turno,Descrição da situação de totalização do candidato naquele turno
+ST_REELEICAO,concorre_reeleicao,"O indicativo de que o candidato está concorrendo ou não à reeleição - pode assumir os valores “S” (sim) e “N” (não) -apenas para os cargos de presidente, governador e prefeito é possível candidatura à reeleição"
+ST_DECLARAR_BENS,declara_bens,O indicativo de que o candidato tem ou não bens a declarar - pode assumiar os valores “S” (em caso positivo) e “N” (em caso negativo)
+NR_PROTOCOLO_CANDIDATURA,numero_protocolo_candidatura,Número do protocolo de registro de candidatura do candidato
+NR_PROCESSO,numero_processo_candidatura,Número do processo de registro de candidatura do candidato
+CD_SITUACAO_CANDIDATO_PLEITO,codigo_situacao_candidato_pleito,
+DS_SITUACAO_CANDIDATO_PLEITO,descricao_situacao_candidato_pleito,
+CD_SITUACAO_CANDIDATO_URNA,codigo_situacao_candidato_urna,
+DS_SITUACAO_CANDIDATO_URNA,descricao_situacao_candidato_urna,
+ST_CANDIDATO_INSERIDO_URNA,candidato_inserido_urna,

--- a/headers/candidatura-final.csv
+++ b/headers/candidatura-final.csv
@@ -41,15 +41,20 @@ numero_partido,"Número do partido. Aparece no TSE como: NUMERO_PARTIDO (1994-BR
 sigla_legenda,Sigla da legenda. Aparece no TSE como: SIGLA_LEGENDA (1994-BR).
 sigla_partido,"Sigla do partido. Aparece no TSE como: SIGLA_PARTIDO (1994-BR), SG_PARTIDO (2018)."
 tipo_agremiacao,Tipo de agremiação - pode assumir os valores “coligação” (quando o candidato concorre por coligação) e “partido isolado” (quando o candidato concorre somente pelo partido). Aparece no TSE como: TP_AGREMIACAO (2018). Coluna adicionada em 2018.
+candidato_inserido_urna,. Aparece no TSE como: ST_CANDIDATO_INSERIDO_URNA (2020). Coluna adicionada em 2020.
 codigo_cargo,"Código do cargo a que o candidato concorre. Aparece no TSE como: CODIGO_CARGO (1994-BR), CD_CARGO (2018)."
 codigo_detalhe_situacao_candidatura,Código do detalhe da situação do registro de candidatura do candidato. Aparece no TSE como: CD_DETALHE_SITUACAO_CAND (2018). Coluna adicionada em 2018.
+codigo_situacao_candidato_pleito,. Aparece no TSE como: CD_SITUACAO_CANDIDATO_PLEITO (2020). Coluna adicionada em 2020.
+codigo_situacao_candidato_urna,. Aparece no TSE como: CD_SITUACAO_CANDIDATO_URNA (2020). Coluna adicionada em 2020.
 codigo_situacao_candidatura,"Código da situação de candidatura. Aparece no TSE como: COD_SITUACAO_CANDIDATURA (1994-BR), CD_SITUACAO_CANDIDATURA (2018)."
 concorre_reeleicao,"O indicativo de que o candidato está concorrendo ou não à reeleição - pode assumir os valores “S” (sim) e “N” (não) -apenas para os cargos de presidente, governador e prefeito é possível candidatura à reeleição. Aparece no TSE como: ST_REELEICAO (2018). Coluna adicionada em 2018."
 declara_bens,O indicativo de que o candidato tem ou não bens a declarar - pode assumiar os valores “S” (em caso positivo) e “N” (em caso negativo). Aparece no TSE como: ST_DECLARAR_BENS (2018). Coluna adicionada em 2018.
 descricao_cargo,"Descrição do cargo a que o candidato concorre. Aparece no TSE como: DESCRICAO_CARGO (1994-BR), DS_CARGO (2018)."
 descricao_detalhe_situacao_candidatura,Descrição do detalhe da situação do registro de candidatura do candidato. Aparece no TSE como: DS_DETALHE_SITUACAO_CAND (2018). Coluna adicionada em 2018.
+descricao_situacao_candidato_pleito,. Aparece no TSE como: DS_SITUACAO_CANDIDATO_PLEITO (2020). Coluna adicionada em 2020.
+descricao_situacao_candidato_urna,. Aparece no TSE como: DS_SITUACAO_CANDIDATO_URNA (2020). Coluna adicionada em 2020.
 descricao_situacao_candidatura,"Descrição da situação de candidatura. Aparece no TSE como: DES_SITUACAO_CANDIDATURA (1994-BR), DS_SITUACAO_CANDIDATURA (2018)."
-despesa_maxima_campanha,"Despesa máxima de campanha declarada pelo partido para aquele cargo. Valores em Reais.. Aparece no TSE como: DESPESA_MAX_CAMPANHA (1994-BR), NR_DESPESA_MAX_CAMPANHA (2018)."
+despesa_maxima_campanha,"Despesa máxima de campanha declarada pelo partido para aquele cargo. Valores em Reais.. Aparece no TSE como: DESPESA_MAX_CAMPANHA (1994-BR), NR_DESPESA_MAX_CAMPANHA (2018), VR_DESPESA_MAX_CAMPANHA (2020)."
 idade_data_eleicao,Idade do candidato da data da eleição. Aparece no TSE como: IDADE_DATA_ELEICAO (1994-BR).
 idade_data_posse,Idade do candidato na data da posse (consultar a data de posse para cada cargo e unidade eleitoral nos arquivos de vagas). Aparece no TSE como: NR_IDADE_DATA_POSSE (2018). Coluna adicionada em 2018.
 nome_urna,"Nome de urna do candidato. Aparece no TSE como: NOME_URNA_CANDIDATO (1994-BR), NM_URNA_CANDIDATO (2018)."

--- a/schema/candidatura.csv
+++ b/schema/candidatura.csv
@@ -58,3 +58,8 @@ numero_processo_candidatura,text
 numero_protocolo_candidatura,text
 numero_sequencial,integer
 numero_urna,integer
+candidato_inserido_urna,text
+codigo_situacao_candidato_pleito,text
+descricao_situacao_candidato_pleito,text
+codigo_situacao_candidato_urna,text
+descricao_situacao_candidato_urna,text

--- a/schema/candidatura.csv
+++ b/schema/candidatura.csv
@@ -58,7 +58,7 @@ numero_processo_candidatura,text
 numero_protocolo_candidatura,text
 numero_sequencial,integer
 numero_urna,integer
-candidato_inserido_urna,text
+candidato_inserido_urna,bool
 codigo_situacao_candidato_pleito,text
 descricao_situacao_candidato_pleito,text
 codigo_situacao_candidato_urna,text


### PR DESCRIPTION
Estende download dos dados de Candidatura de 2020 disponíveis pelo [TSE](http://www.tse.jus.br/hotsites/pesquisas-eleitorais/candidatos_anos/2020.html)

Alguns campos foram adicionados nesse ano:

 **ST_CANDIDATO_INSERIDO_URNA** -> `candidato_inserido_urna`
**CD_SITUACAO_CANDIDATO_PLEITO** -> `codigo_situacao_candidato_pleito`
**CD_SITUACAO_CANDIDATO_URNA** ->  `codigo_situacao_candidato_urna`
**DS_SITUACAO_CANDIDATO_PLEITO** -> `descricao_situacao_candidato_pleito`
**DS_SITUACAO_CANDIDATO_URNA** ->  `descricao_situacao_candidato_urna`

O campo **VR_DESPESA_MAX_CAMPANHA** `despesa_maxima_campanha`, era anteriormente denominado **NR_DESPESA_MAX_CAMPANHA**


**OBS[0]**: Ainda não encontrei o arquivo **leaime.pdf** com a descrição dos novos campos
**OBS[1]**:  Existem planilhas com sufixo _todos que ainda não descobri o propósito. Por enquanto, estou ignorando essas planilhas, pois parecem trazer as mesmas informações do que as outras tabelas.