### PR TITLE
Estende download de bem declarado para 2020

### DIFF
--- a/extractors.py
+++ b/extractors.py
@@ -381,7 +381,7 @@ class CandidaturaExtractor(Extractor):
 
 class BemDeclaradoExtractor(Extractor):
 
-    year_range = tuple(range(2006, FINAL_VOTATION_YEAR, 2))
+    year_range = tuple(range(2006, FINAL_VOTATION_YEAR + 1, 2))
     schema_filename = settings.SCHEMA_PATH / "bem-declarado.csv"
 
     def url(self, year):
@@ -392,13 +392,17 @@ class BemDeclaradoExtractor(Extractor):
 
     def valid_filename(self, filename):
         name = filename.lower()
-        return name.startswith("bem_candidato") and "_brasil.csv" not in name
+        return (
+            name.startswith("bem_candidato")
+            and "_brasil.csv" not in name
+            and not name.endswith("todos.csv")
+        )
 
     def get_headers(self, year, filename, internal_filename):
         uf = self.extract_state_from_filename(internal_filename)
         if 2006 <= year <= 2012:
             header_year = "2006"
-        elif 2014 <= year <= 2018:
+        elif 2014 <= year <= 2020:
             header_year = "2014"
         else:
             raise ValueError("Unrecognized year")


### PR DESCRIPTION
Estende download dos dados de Bem Declarado de 2020 disponíveis pelo [TSE](http://www.tse.jus.br/hotsites/pesquisas-eleitorais/candidatos_anos/2020.html).

Os dados quase não mudaram, com excessão das planilhas com sufixo **_todos**, que ainda não descobri o propósito. Por enquanto, estou ignorando essas planilhas, pois parecem trazer as mesmas informações do que as outras tabelas.