### PR TITLE
Ajustes nos headers para download dos dados de bens declarados e candidaturas

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ conversões dos dados, como:
 
 - Retirar todos os acentos: alguns nomes aparecem com acentos em um ano e sem
   em outros, dificultando muito os agrupamentos;
-- Retirar strings inúteis: valores como `#NULO#`, `#NULO` e `#NE#` são
+- Retirar strings inúteis: valores como `#NULO#`, `#NULO`, `#NE` e `#NE#` são
   retirados, deixando as células em branco;
 - Normalização dos códigos de cargo: os códigos de cargo variam para alguns
   anos, tornando difícil o agrupamento entre anos e, para facilitar as

--- a/extractors.py
+++ b/extractors.py
@@ -2,9 +2,8 @@ import csv
 import re
 from datetime import datetime
 from functools import lru_cache
-from io import StringIO, TextIOWrapper, BytesIO
+from io import StringIO, TextIOWrapper
 from pathlib import Path
-from shutil import move as move_file
 from shutil import move as rename_file
 from urllib.parse import urljoin
 from zipfile import ZipFile

--- a/extractors.py
+++ b/extractors.py
@@ -354,7 +354,7 @@ class CandidaturaExtractor(Extractor):
             new = {}
             for key in final_field_names:
                 value = row.get(key, "").strip()
-                if value in ("#NULO", "#NULO#", "#NE#"):
+                if value in ("#NULO", "#NULO#", "#NE#", "#NE"):
                     value = ""
                 new[key] = value = utils.unaccent(value).upper()
 

--- a/filiacao_download.py
+++ b/filiacao_download.py
@@ -1,13 +1,10 @@
-import io
 import os
 import random
 import string
 import tempfile
-from collections import OrderedDict
 from urllib.parse import urljoin
 from pathlib import Path
 
-import rows
 import scrapy
 
 import settings

--- a/headers/bem-declarado-2006.csv
+++ b/headers/bem-declarado-2006.csv
@@ -1,13 +1,20 @@
 nome_tse,nome_final,descricao
-DATA_GERACAO,,Data de geração do arquivo (data da extração)
-HORA_GERACAO,,Hora de geração do arquivo (hora da extração) - Horário de Brasília
+DT_GERACAO,,Data de geração do arquivo (data da extração)
+HH_GERACAO,,Hora de geração do arquivo (hora da extração) - Horário de Brasília
 ANO_ELEICAO,ano,Ano da eleição
-DESCRICAO_ELEICAO,eleicao,Descrição da eleição
-SIGLA_UF,sigla_unidade_federativa,Sigla da Unidade da Federação em que ocorreu a eleição
+CD_TIPO_ELEICAO,codigo_tipo_eleicao,Código do tipo de eleição
+NM_TIPO_ELEICAO,tipo_eleicao,Nome do tipo de eleição
+CD_ELEICAO,codigo_eleicao,Código da eleição
+DS_ELEICAO,eleicao,Descrição da eleição
+DT_ELEICAO,data_eleicao,Data em que ocorreu a eleição
+SG_UF,sigla_unidade_federativa,Sigla da Unidade da Federação em que ocorreu a eleição
+SG_UE,sigla_unidade_eleitoral,Sigla da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município)
+NM_UE,unidade_eleitoral,Nome da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município)
 SQ_CANDIDATO,numero_sequencial,Número sequencial do candidato gerado internamente pelos sistemas eleitorais. Não é o número de campanha do candidato.
+NR_ORDEM_CANDIDATO,numero_ordem,Número da ordem do bem declarado do candidato
 CD_TIPO_BEM_CANDIDATO,codigo_tipo,Código do tipo do bem do candidato
 DS_TIPO_BEM_CANDIDATO,tipo,Descrição do tipo do bem do candidato
-DETALHE_BEM,detalhe,Detalhe do bem do candidato
-VALOR_BEM,valor,Valor declarado do bem do candidato
-DATA_ULTIMA_ATUALIZACAO,data_ultima_atualizacao,Data da última atualização do registro do bem
-HORA_ULTIMA_ATUALIZACAO,hora_ultima_atualizacao,Hora da última atualização do registro do bem
+DS_BEM_CANDIDATO,detalhe,Detalhe do bem do candidato
+VR_BEM_CANDIDATO,valor,Valor declarado do bem do candidato
+DT_ULTIMA_ATUALIZACAO,data_ultima_atualizacao,Data da última atualização do registro do bem
+HH_ULTIMA_ATUALIZACAO,hora_ultima_atualizacao,Hora da última atualização do registro do bem

--- a/headers/bem-declarado-final.csv
+++ b/headers/bem-declarado-final.csv
@@ -1,18 +1,18 @@
 nome_final,descricao
-codigo_eleicao,Código da eleição. Aparece no TSE como: CD_ELEICAO (2014). Coluna adicionada em 2014.
-codigo_tipo_eleicao,Código do tipo de eleição. Aparece no TSE como: CD_TIPO_ELEICAO (2014). Coluna adicionada em 2014.
-data_eleicao,Data em que ocorreu a eleição. Aparece no TSE como: DT_ELEICAO (2014). Coluna adicionada em 2014.
-tipo_eleicao,Nome do tipo de eleição. Aparece no TSE como: NM_TIPO_ELEICAO (2014). Coluna adicionada em 2014.
-sigla_unidade_eleitoral,Sigla da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município). Aparece no TSE como: SG_UE (2014). Coluna adicionada em 2014.
-sigla_unidade_federativa,"Sigla da Unidade da Federação em que ocorreu a eleição. Aparece no TSE como: SIGLA_UF (2006), SG_UF (2014)."
+codigo_eleicao,Código da eleição. Aparece no TSE como: CD_ELEICAO (2006).
+codigo_tipo_eleicao,Código do tipo de eleição. Aparece no TSE como: CD_TIPO_ELEICAO (2006).
+data_eleicao,Data em que ocorreu a eleição. Aparece no TSE como: DT_ELEICAO (2006).
+tipo_eleicao,Nome do tipo de eleição. Aparece no TSE como: NM_TIPO_ELEICAO (2006).
+sigla_unidade_eleitoral,Sigla da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município). Aparece no TSE como: SG_UE (2006).
+sigla_unidade_federativa,Sigla da Unidade da Federação em que ocorreu a eleição. Aparece no TSE como: SG_UF (2006).
 numero_sequencial,Número sequencial do candidato gerado internamente pelos sistemas eleitorais. Não é o número de campanha do candidato.. Aparece no TSE como: SQ_CANDIDATO (2006).
 ano,Ano da eleição. Aparece no TSE como: ANO_ELEICAO (2006).
 codigo_tipo,Código do tipo do bem do candidato. Aparece no TSE como: CD_TIPO_BEM_CANDIDATO (2006).
-data_ultima_atualizacao,"Data da última atualização do registro do bem. Aparece no TSE como: DATA_ULTIMA_ATUALIZACAO (2006), DT_ULTIMA_ATUALIZACAO (2014)."
-detalhe,"Detalhe do bem do candidato. Aparece no TSE como: DETALHE_BEM (2006), DS_BEM_CANDIDATO (2014)."
-eleicao,"Descrição da eleição. Aparece no TSE como: DESCRICAO_ELEICAO (2006), DS_ELEICAO (2014)."
-hora_ultima_atualizacao,"Hora da última atualização do registro do bem. Aparece no TSE como: HORA_ULTIMA_ATUALIZACAO (2006), HH_ULTIMA_ATUALIZACAO (2014)."
-numero_ordem,Número da ordem do bem declarado do candidato. Aparece no TSE como: NR_ORDEM_CANDIDATO (2014). Coluna adicionada em 2014.
+data_ultima_atualizacao,Data da última atualização do registro do bem. Aparece no TSE como: DT_ULTIMA_ATUALIZACAO (2006).
+detalhe,Detalhe do bem do candidato. Aparece no TSE como: DS_BEM_CANDIDATO (2006).
+eleicao,Descrição da eleição. Aparece no TSE como: DS_ELEICAO (2006).
+hora_ultima_atualizacao,Hora da última atualização do registro do bem. Aparece no TSE como: HH_ULTIMA_ATUALIZACAO (2006).
+numero_ordem,Número da ordem do bem declarado do candidato. Aparece no TSE como: NR_ORDEM_CANDIDATO (2006).
 tipo,Descrição do tipo do bem do candidato. Aparece no TSE como: DS_TIPO_BEM_CANDIDATO (2006).
-unidade_eleitoral,Nome da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município). Aparece no TSE como: NM_UE (2014). Coluna adicionada em 2014.
-valor,"Valor declarado do bem do candidato. Aparece no TSE como: VALOR_BEM (2006), VR_BEM_CANDIDATO (2014)."
+unidade_eleitoral,Nome da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município). Aparece no TSE como: NM_UE (2006).
+valor,Valor declarado do bem do candidato. Aparece no TSE como: VR_BEM_CANDIDATO (2006).

--- a/headers/candidatura-1996.csv
+++ b/headers/candidatura-1996.csv
@@ -1,44 +1,64 @@
 nome_tse,nome_final,descricao
-DATA_GERACAO,,Data de geração do arquivo (data da extração)
-HORA_GERACAO,,Hora de geração do arquivo (hora da extração) - Horário de Brasília
-ANO_ELEICAO,ano,Ano da eleição
-NUM_TURNO,turno,Número do turno
-DESCRICAO_ELEICAO,eleicao,Descrição da eleição
-SIGLA_UF,sigla_unidade_federativa,Sigla da Unidade da Federação em que ocorreu a eleição
-SIGLA_UE,sigla_unidade_eleitoral,"Sigla da Unidade Eleitoral (Em caso de eleição majoritária é a sigla da UF que o candidato concorre (texto) e em caso de eleição municipal é o código TSE do município (número)). Assume os valores especiais BR, ZZ e VT para designar, respectivamente, o Brasil, Exterior e Voto em Trânsito"
-DESCRICAO_UE,unidade_eleitoral,Descrição da Unidade Eleitoral
-CODIGO_CARGO,codigo_cargo,Código do cargo a que o candidato concorre
-DESCRICAO_CARGO,cargo,Descrição do cargo a que o candidato concorre
-NOME_CANDIDATO,nome,Nome completo do candidato
-SEQUENCIAL_CANDIDATO,numero_sequencial,Número sequencial do candidato gerado internamente pelos sistemas eleitorais. Não é o número de campanha do candidato.
-NUMERO_CANDIDATO,numero_urna,Número do candidato na urna
-CPF_CANDIDATO,cpf,CPF do candidato
-NOME_URNA_CANDIDATO,nome_urna,Nome de urna do candidato
-COD_SITUACAO_CANDIDATURA,codigo_situacao_candidatura,Código da situação de candidatura
-DES_SITUACAO_CANDIDATURA,situacao_candidatura,Descrição da situação de candidatura
-NUMERO_PARTIDO,numero_partido,Número do partido
-SIGLA_PARTIDO,sigla_partido,Sigla do partido
-NOME_PARTIDO,partido,Nome do partido
-CODIGO_LEGENDA,codigo_legenda,Código sequencial da legenda gerado pela Justiça Eleitoral
-SIGLA_LEGENDA,sigla_legenda,Sigla da legenda
-COMPOSICAO_LEGENDA,composicao_legenda,Composição da legenda
-NOME_LEGENDA,legenda,Nome da legenda
-CODIGO_OCUPACAO,codigo_ocupacao,Código da ocupação do candidato
-DESCRICAO_OCUPACAO,ocupacao,Descrição da ocupação do candidato
-DATA_NASCIMENTO,data_nascimento,Data de nascimento do candidato
-NUM_TITULO_ELEITORAL_CANDIDATO,titulo_eleitoral,Número do título eleitoral do candidato
-IDADE_DATA_ELEICAO,idade_data_eleicao,Idade do candidato da data da eleição
-CODIGO_SEXO,codigo_genero,Código do sexo do candidato
-DESCRICAO_SEXO,genero,Descrição do sexo do candidato
-COD_GRAU_INSTRUCAO,codigo_grau_instrucao,Código do grau de instrução do candidato. Gerado internamente pelos sistemas eleitorais
-DESCRICAO_GRAU_INSTRUCAO,grau_instrucao,Descrição do grau de instrução do candidato
-CODIGO_ESTADO_CIVIL,codigo_estado_civil,Código do estado civil do candidato
-DESCRICAO_ESTADO_CIVIL,estado_civil,Descrição do estado civil do candidato
-CODIGO_NACIONALIDADE,codigo_nacionalidade,Código da nacionalidade do candidato
-DESCRICAO_NACIONALIDADE,nacionalidade,Descrição da nacionalidade do candidato
-SIGLA_UF_NASCIMENTO,sigla_unidade_federativa_nascimento,Sigla da UF de nascimento do candidato
-CODIGO_MUNICIPIO_NASCIMENTO,codigo_municipio_nascimento,Código TSE do município da nascimento do candidato
-NOME_MUNICIPIO_NASCIMENTO,municipio_nascimento,Nome do município de nascimento do candidato
-DESPESA_MAX_CAMPANHA,despesa_maxima_campanha,Despesa máxima de campanha declarada pelo partido para aquele cargo. Valores em Reais.
-COD_SIT_TOT_TURNO,codigo_totalizacao_turno,Código da situação de totalização do candidato naquele turno
-DESC_SIT_TOT_TURNO,totalizacao_turno,Descrição da situação de totalização do candidato naquele turno
+DT_GERACAO,,Data de geração do arquivo (data da extração dos dados)
+HH_GERACAO,,Hora de geração do arquivo (hora da extração) - Horário de Brasília
+ANO_ELEICAO,ano,Ano da eleição (referente ao ano eleitoral de pesquisa)
+CD_TIPO_ELEICAO,codigo_tipo_eleicao,Código do tipo de eleição
+NM_TIPO_ELEICAO,tipo_eleicao,Nome do tipo de eleição
+NR_TURNO,turno,Número do turno da eleição
+CD_ELEICAO,codigo_eleicao,Código da eleição
+DS_ELEICAO,eleicao,Descrição da eleição
+DT_ELEICAO,data_eleicao,Data em que ocorreu a eleição
+TP_ABRANGENCIA,tipo_abrangencia_eleicao,Tipo de abrangência da eleição
+SG_UF,sigla_unidade_federativa,Sigla da Unidade da Federação em que ocorreu a eleição
+SG_UE,sigla_unidade_eleitoral,Sigla da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município)
+NM_UE,unidade_eleitoral,Nome da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município)
+CD_CARGO,codigo_cargo,Código do cargo ao qual o candidato concorre
+DS_CARGO,cargo,Descrição do cargo ao qual o candidato concorre
+SQ_CANDIDATO,numero_sequencial,Número sequencial do candidato gerado internamente pelos sistemas eleitorais (não é o número da campanha do candidato)
+NR_CANDIDATO,numero_urna,Nümero do candidato na urna
+NM_CANDIDATO,nome,Nome completo do candidato
+NM_URNA_CANDIDATO,nome_urna,Nome de urna do candidato
+NM_SOCIAL_CANDIDATO,nome_social,Nome social do candidato
+NR_CPF_CANDIDATO,cpf,Número do CPF do candidato
+NM_EMAIL,email,Endereço de e-mail do candidato
+CD_SITUACAO_CANDIDATURA,codigo_situacao_candidatura,Código da situação do registro de candidatura do candidato
+DS_SITUACAO_CANDIDATURA,situacao_candidatura,"Descrição da situação do registro de candidatura do candidato - pode assumir os valores “apto (apto para ir para urna)”, “inapto” (inapto para ir para urna) e “cadastrado” (registro de candidatura realizado, mas ainda não julgado)"
+CD_DETALHE_SITUACAO_CAND,codigo_detalhe_situacao_candidatura,Código do detalhe da situação do registro de candidatura do candidato
+DS_DETALHE_SITUACAO_CAND,detalhe_situacao_candidatura,Descrição do detalhe da situação do registro de candidatura do candidato
+TP_AGREMIACAO,tipo_agremiacao,Tipo de agremiação - pode assumir os valores “coligação” (quando o candidato concorre por coligação) e “partido isolado” (quando o candidato concorre somente pelo partido)
+NR_PARTIDO,numero_partido,Número do partido do candidato
+SG_PARTIDO,sigla_partido,Sigla do partido do candidato
+NM_PARTIDO,partido,Nome do partido do candidato
+SQ_COLIGACAO,codigo_legenda,Número sequencial da coligação da qual o candidato pertence
+NM_COLIGACAO,legenda,Nome da coligação da qual o candidato pertence
+DS_COMPOSICAO_COLIGACAO,composicao_legenda,Descrição da composição da coligação da qual o candidato pertence
+CD_NACIONALIDADE,codigo_nacionalidade,Código da nacionalidade do candidato
+DS_NACIONALIDADE,nacionalidade,Descrição da nacionalidade do candidato
+SG_UF_NASCIMENTO,sigla_unidade_federativa_nascimento,Sigla da UF de nascimento do candidato
+CD_MUNICIPIO_NASCIMENTO,codigo_municipio_nascimento,Código TSE do município de nascimento do candidato
+NM_MUNICIPIO_NASCIMENTO,municipio_nascimento,Nome do município de nascimento do candidato
+DT_NASCIMENTO,data_nascimento,Data de nascimento do candidato
+NR_IDADE_DATA_POSSE,idade_data_posse,Idade do candidato na data da posse (consultar a data de posse para cada cargo e unidade eleitoral nos arquivos de vagas)
+NR_TITULO_ELEITORAL_CANDIDATO,titulo_eleitoral,Número do título eleitoral do candidato
+CD_GENERO,codigo_genero,Código do gênero do candidato
+DS_GENERO,genero,Descrição do gênero do candidato
+CD_GRAU_INSTRUCAO,codigo_grau_instrucao,Código do grau de instrução do candidato
+DS_GRAU_INSTRUCAO,grau_instrucao,Descrição do grau de instrução do candidato
+CD_ESTADO_CIVIL,codigo_estado_civil,Código do estado civil do candidato
+DS_ESTADO_CIVIL,estado_civil,Descrição do estado civil do candidato
+CD_COR_RACA,codigo_etnia,Código da etnia (cor/raça) do candidato (auto declaração)
+DS_COR_RACA,etnia,Etnia (cor/raça) do candidato (auto declaração)
+CD_OCUPACAO,codigo_ocupacao,Código da ocupação do candidato
+DS_OCUPACAO,ocupacao,Descrição da ocupação do candidato
+VR_DESPESA_MAX_CAMPANHA,despesa_maxima_campanha,"Despesa máxima de campanha declarada pelo partido para aquele cargo, em reais - os valores máximos para candidatos a vice e suplentes serão incluídos nos valores indicados para os titulares (quando não informado o valor será -1)"
+CD_SIT_TOT_TURNO,codigo_totalizacao_turno,Código da situação de totalização do candidato naquele turno
+DS_SIT_TOT_TURNO,totalizacao_turno,Descrição da situação de totalização do candidato naquele turno
+ST_REELEICAO,concorre_reeleicao,"O indicativo de que o candidato está concorrendo ou não à reeleição - pode assumir os valores “S” (sim) e “N” (não) -apenas para os cargos de presidente, governador e prefeito é possível candidatura à reeleição"
+ST_DECLARAR_BENS,declara_bens,O indicativo de que o candidato tem ou não bens a declarar - pode assumiar os valores “S” (em caso positivo) e “N” (em caso negativo)
+NR_PROTOCOLO_CANDIDATURA,numero_protocolo_candidatura,Número do protocolo de registro de candidatura do candidato
+NR_PROCESSO,numero_processo_candidatura,Número do processo de registro de candidatura do candidato
+CD_SITUACAO_CANDIDATO_PLEITO,codigo_situacao_candidatura_pleito,
+DS_SITUACAO_CANDIDATO_PLEITO,situacao_candidatura_pleito,
+CD_SITUACAO_CANDIDATO_URNA,codigo_situacao_candidatura_urna,
+DS_SITUACAO_CANDIDATO_URNA,situacao_candidatura_urna,
+ST_CANDIDATO_INSERIDO_URNA,candidatura_inserida_urna,

--- a/headers/candidatura-2012.csv
+++ b/headers/candidatura-2012.csv
@@ -1,45 +1,64 @@
 nome_tse,nome_final,descricao
-DATA_GERACAO,,Data de geração do arquivo (data da extração)
-HORA_GERACAO,,Hora de geração do arquivo (hora da extração) - Horário de Brasília
-ANO_ELEICAO,ano,Ano da eleição
-NUM_TURNO,turno,Número do turno
-DESCRICAO_ELEICAO,eleicao,Descrição da eleição
-SIGLA_UF,sigla_unidade_federativa,Sigla da Unidade da Federação em que ocorreu a eleição
-SIGLA_UE,sigla_unidade_eleitoral,"Sigla da Unidade Eleitoral (Em caso de eleição majoritária é a sigla da UF que o candidato concorre (texto) e em caso de eleição municipal é o código TSE do município (número)). Assume os valores especiais BR, ZZ e VT para designar, respectivamente, o Brasil, Exterior e Voto em Trânsito"
-DESCRICAO_UE,unidade_eleitoral,Descrição da Unidade Eleitoral
-CODIGO_CARGO,codigo_cargo,Código do cargo a que o candidato concorre
-DESCRICAO_CARGO,cargo,Descrição do cargo a que o candidato concorre
-NOME_CANDIDATO,nome,Nome completo do candidato
-SEQUENCIAL_CANDIDATO,numero_sequencial,Número sequencial do candidato gerado internamente pelos sistemas eleitorais. Não é o número de campanha do candidato.
-NUMERO_CANDIDATO,numero_urna,Número do candidato na urna
-CPF_CANDIDATO,cpf,CPF do candidato
-NOME_URNA_CANDIDATO,nome_urna,Nome de urna do candidato
-COD_SITUACAO_CANDIDATURA,codigo_situacao_candidatura,Código da situação de candidatura
-DES_SITUACAO_CANDIDATURA,situacao_candidatura,Descrição da situação de candidatura
-NUMERO_PARTIDO,numero_partido,Número do partido
-SIGLA_PARTIDO,sigla_partido,Sigla do partido
-NOME_PARTIDO,partido,Nome do partido
-CODIGO_LEGENDA,codigo_legenda,Código sequencial da legenda gerado pela Justiça Eleitoral
-SIGLA_LEGENDA,sigla_legenda,Sigla da legenda
-COMPOSICAO_LEGENDA,composicao_legenda,Composição da legenda
-NOME_LEGENDA,legenda,Nome da legenda
-CODIGO_OCUPACAO,codigo_ocupacao,Código da ocupação do candidato
-DESCRICAO_OCUPACAO,ocupacao,Descrição da ocupação do candidato
-DATA_NASCIMENTO,data_nascimento,Data de nascimento do candidato
-NUM_TITULO_ELEITORAL_CANDIDATO,titulo_eleitoral,Número do título eleitoral do candidato
-IDADE_DATA_ELEICAO,idade_data_eleicao,Idade do candidato da data da eleição
-CODIGO_SEXO,codigo_genero,Código do sexo do candidato
-DESCRICAO_SEXO,genero,Descrição do sexo do candidato
-COD_GRAU_INSTRUCAO,codigo_grau_instrucao,Código do grau de instrução do candidato. Gerado internamente pelos sistemas eleitorais
-DESCRICAO_GRAU_INSTRUCAO,grau_instrucao,Descrição do grau de instrução do candidato
-CODIGO_ESTADO_CIVIL,codigo_estado_civil,Código do estado civil do candidato
-DESCRICAO_ESTADO_CIVIL,estado_civil,Descrição do estado civil do candidato
-CODIGO_NACIONALIDADE,codigo_nacionalidade,Código da nacionalidade do candidato
-DESCRICAO_NACIONALIDADE,nacionalidade,Descrição da nacionalidade do candidato
-SIGLA_UF_NASCIMENTO,sigla_unidade_federativa_nascimento,Sigla da UF de nascimento do candidato
-CODIGO_MUNICIPIO_NASCIMENTO,codigo_municipio_nascimento,Código TSE do município da nascimento do candidato
-NOME_MUNICIPIO_NASCIMENTO,municipio_nascimento,Nome do município de nascimento do candidato
-DESPESA_MAX_CAMPANHA,despesa_maxima_campanha,Despesa máxima de campanha declarada pelo partido para aquele cargo. Valores em Reais.
-COD_SIT_TOT_TURNO,codigo_totalizacao_turno,Código da situação de totalização do candidato naquele turno
-DESC_SIT_TOT_TURNO,totalizacao_turno,Descrição da situação de totalização do candidato naquele turno
-NM_EMAIL,email,E-mail para comunicação com o candidato
+DT_GERACAO,,Data de geração do arquivo (data da extração dos dados)
+HH_GERACAO,,Hora de geração do arquivo (hora da extração) - Horário de Brasília
+ANO_ELEICAO,ano,Ano da eleição (referente ao ano eleitoral de pesquisa)
+CD_TIPO_ELEICAO,codigo_tipo_eleicao,Código do tipo de eleição
+NM_TIPO_ELEICAO,tipo_eleicao,Nome do tipo de eleição
+NR_TURNO,turno,Número do turno da eleição
+CD_ELEICAO,codigo_eleicao,Código da eleição
+DS_ELEICAO,eleicao,Descrição da eleição
+DT_ELEICAO,data_eleicao,Data em que ocorreu a eleição
+TP_ABRANGENCIA,tipo_abrangencia_eleicao,Tipo de abrangência da eleição
+SG_UF,sigla_unidade_federativa,Sigla da Unidade da Federação em que ocorreu a eleição
+SG_UE,sigla_unidade_eleitoral,Sigla da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município)
+NM_UE,unidade_eleitoral,Nome da Unidade Eleitoral do candidato (em caso de eleição majoritária é a sigla da UF que o candidato concorre e em caso de eleição municipal é o código TSE do município)
+CD_CARGO,codigo_cargo,Código do cargo ao qual o candidato concorre
+DS_CARGO,cargo,Descrição do cargo ao qual o candidato concorre
+SQ_CANDIDATO,numero_sequencial,Número sequencial do candidato gerado internamente pelos sistemas eleitorais (não é o número da campanha do candidato)
+NR_CANDIDATO,numero_urna,Nümero do candidato na urna
+NM_CANDIDATO,nome,Nome completo do candidato
+NM_URNA_CANDIDATO,nome_urna,Nome de urna do candidato
+NM_SOCIAL_CANDIDATO,nome_social,Nome social do candidato
+NR_CPF_CANDIDATO,cpf,Número do CPF do candidato
+NM_EMAIL,email,Endereço de e-mail do candidato
+CD_SITUACAO_CANDIDATURA,codigo_situacao_candidatura,Código da situação do registro de candidatura do candidato
+DS_SITUACAO_CANDIDATURA,situacao_candidatura,"Descrição da situação do registro de candidatura do candidato - pode assumir os valores “apto (apto para ir para urna)”, “inapto” (inapto para ir para urna) e “cadastrado” (registro de candidatura realizado, mas ainda não julgado)"
+CD_DETALHE_SITUACAO_CAND,codigo_detalhe_situacao_candidatura,Código do detalhe da situação do registro de candidatura do candidato
+DS_DETALHE_SITUACAO_CAND,detalhe_situacao_candidatura,Descrição do detalhe da situação do registro de candidatura do candidato
+TP_AGREMIACAO,tipo_agremiacao,Tipo de agremiação - pode assumir os valores “coligação” (quando o candidato concorre por coligação) e “partido isolado” (quando o candidato concorre somente pelo partido)
+NR_PARTIDO,numero_partido,Número do partido do candidato
+SG_PARTIDO,sigla_partido,Sigla do partido do candidato
+NM_PARTIDO,partido,Nome do partido do candidato
+SQ_COLIGACAO,codigo_legenda,Número sequencial da coligação da qual o candidato pertence
+NM_COLIGACAO,legenda,Nome da coligação da qual o candidato pertence
+DS_COMPOSICAO_COLIGACAO,composicao_legenda,Descrição da composição da coligação da qual o candidato pertence
+CD_NACIONALIDADE,codigo_nacionalidade,Código da nacionalidade do candidato
+DS_NACIONALIDADE,nacionalidade,Descrição da nacionalidade do candidato
+SG_UF_NASCIMENTO,sigla_unidade_federativa_nascimento,Sigla da UF de nascimento do candidato
+CD_MUNICIPIO_NASCIMENTO,codigo_municipio_nascimento,Código TSE do município de nascimento do candidato
+NM_MUNICIPIO_NASCIMENTO,municipio_nascimento,Nome do município de nascimento do candidato
+DT_NASCIMENTO,data_nascimento,Data de nascimento do candidato
+NR_IDADE_DATA_POSSE,idade_data_posse,Idade do candidato na data da posse (consultar a data de posse para cada cargo e unidade eleitoral nos arquivos de vagas)
+NR_TITULO_ELEITORAL_CANDIDATO,titulo_eleitoral,Número do título eleitoral do candidato
+CD_GENERO,codigo_genero,Código do gênero do candidato
+DS_GENERO,genero,Descrição do gênero do candidato
+CD_GRAU_INSTRUCAO,codigo_grau_instrucao,Código do grau de instrução do candidato
+DS_GRAU_INSTRUCAO,grau_instrucao,Descrição do grau de instrução do candidato
+CD_ESTADO_CIVIL,codigo_estado_civil,Código do estado civil do candidato
+DS_ESTADO_CIVIL,estado_civil,Descrição do estado civil do candidato
+CD_COR_RACA,codigo_etnia,Código da etnia (cor/raça) do candidato (auto declaração)
+DS_COR_RACA,etnia,Etnia (cor/raça) do candidato (auto declaração)
+CD_OCUPACAO,codigo_ocupacao,Código da ocupação do candidato
+DS_OCUPACAO,ocupacao,Descrição da ocupação do candidato
+VR_DESPESA_MAX_CAMPANHA,despesa_maxima_campanha,"Despesa máxima de campanha declarada pelo partido para aquele cargo, em reais - os valores máximos para candidatos a vice e suplentes serão incluídos nos valores indicados para os titulares (quando não informado o valor será -1)"
+CD_SIT_TOT_TURNO,codigo_totalizacao_turno,Código da situação de totalização do candidato naquele turno
+DS_SIT_TOT_TURNO,totalizacao_turno,Descrição da situação de totalização do candidato naquele turno
+ST_REELEICAO,concorre_reeleicao,"O indicativo de que o candidato está concorrendo ou não à reeleição - pode assumir os valores “S” (sim) e “N” (não) -apenas para os cargos de presidente, governador e prefeito é possível candidatura à reeleição"
+ST_DECLARAR_BENS,declara_bens,O indicativo de que o candidato tem ou não bens a declarar - pode assumiar os valores “S” (em caso positivo) e “N” (em caso negativo)
+NR_PROTOCOLO_CANDIDATURA,numero_protocolo_candidatura,Número do protocolo de registro de candidatura do candidato
+NR_PROCESSO,numero_processo_candidatura,Número do processo de registro de candidatura do candidato
+CD_SITUACAO_CANDIDATO_PLEITO,codigo_situacao_candidatura_pleito,
+DS_SITUACAO_CANDIDATO_PLEITO,situacao_candidatura_pleito,
+CD_SITUACAO_CANDIDATO_URNA,codigo_situacao_candidatura_urna,
+DS_SITUACAO_CANDIDATO_URNA,situacao_candidatura_urna,
+ST_CANDIDATO_INSERIDO_URNA,candidatura_inserida_urna,

--- a/headers/candidatura-2014.csv
+++ b/headers/candidatura-2014.csv
@@ -50,10 +50,15 @@ CD_COR_RACA,codigo_etnia,Código da etnia (cor/raça) do candidato (auto declara
 DS_COR_RACA,etnia,Etnia (cor/raça) do candidato (auto declaração)
 CD_OCUPACAO,codigo_ocupacao,Código da ocupação do candidato
 DS_OCUPACAO,ocupacao,Descrição da ocupação do candidato
-NR_DESPESA_MAX_CAMPANHA,despesa_maxima_campanha,"Despesa máxima de campanha declarada pelo partido para aquele cargo, em reais - os valores máximos para candidatos a vice e suplentes serão incluídos nos valores indicados para os titulares (quando não informado o valor será -1)"
+VR_DESPESA_MAX_CAMPANHA,despesa_maxima_campanha,"Despesa máxima de campanha declarada pelo partido para aquele cargo, em reais - os valores máximos para candidatos a vice e suplentes serão incluídos nos valores indicados para os titulares (quando não informado o valor será -1)"
 CD_SIT_TOT_TURNO,codigo_totalizacao_turno,Código da situação de totalização do candidato naquele turno
 DS_SIT_TOT_TURNO,totalizacao_turno,Descrição da situação de totalização do candidato naquele turno
 ST_REELEICAO,concorre_reeleicao,"O indicativo de que o candidato está concorrendo ou não à reeleição - pode assumir os valores “S” (sim) e “N” (não) -apenas para os cargos de presidente, governador e prefeito é possível candidatura à reeleição"
 ST_DECLARAR_BENS,declara_bens,O indicativo de que o candidato tem ou não bens a declarar - pode assumiar os valores “S” (em caso positivo) e “N” (em caso negativo)
 NR_PROTOCOLO_CANDIDATURA,numero_protocolo_candidatura,Número do protocolo de registro de candidatura do candidato
 NR_PROCESSO,numero_processo_candidatura,Número do processo de registro de candidatura do candidato
+CD_SITUACAO_CANDIDATO_PLEITO,codigo_situacao_candidatura_pleito,
+DS_SITUACAO_CANDIDATO_PLEITO,situacao_candidatura_pleito,
+CD_SITUACAO_CANDIDATO_URNA,codigo_situacao_candidatura_urna,
+DS_SITUACAO_CANDIDATO_URNA,situacao_candidatura_urna,
+ST_CANDIDATO_INSERIDO_URNA,candidatura_inserida_urna,

--- a/headers/candidatura-final.csv
+++ b/headers/candidatura-final.csv
@@ -1,64 +1,64 @@
 nome_final,descricao
-codigo_eleicao,Código da eleição. Aparece no TSE como: CD_ELEICAO (2014). Coluna adicionada em 2014.
-codigo_tipo_eleicao,Código do tipo de eleição. Aparece no TSE como: CD_TIPO_ELEICAO (2014). Coluna adicionada em 2014.
-data_eleicao,Data em que ocorreu a eleição. Aparece no TSE como: DT_ELEICAO (2014). Coluna adicionada em 2014.
-eleicao,"Descrição da eleição. Aparece no TSE como: DESCRICAO_ELEICAO (1994-BR), DS_ELEICAO (2014)."
-tipo_abrangencia_eleicao,Tipo de abrangência da eleição. Aparece no TSE como: TP_ABRANGENCIA (2014). Coluna adicionada em 2014.
-tipo_eleicao,Nome do tipo de eleição. Aparece no TSE como: NM_TIPO_ELEICAO (2014). Coluna adicionada em 2014.
-codigo_totalizacao_turno,"Código da situação de totalização do candidato naquele turno. Aparece no TSE como: COD_SIT_TOT_TURNO (1994-BR), CD_SIT_TOT_TURNO (2014)."
-totalizacao_turno,"Descrição da situação de totalização do candidato naquele turno. Aparece no TSE como: DESC_SIT_TOT_TURNO (1994-BR), DS_SIT_TOT_TURNO (2014)."
-turno,"Número do turno. Aparece no TSE como: NUM_TURNO (1994-BR), NR_TURNO (2014)."
-sigla_unidade_eleitoral,"Sigla da Unidade Eleitoral (Em caso de eleição majoritária é a sigla da UF que o candidato concorre (texto) e em caso de eleição municipal é o código TSE do município (número)). Assume os valores especiais BR, ZZ e VT para designar, respectivamente, o Brasil, Exterior e Voto em Trânsito. Aparece no TSE como: SIGLA_UE (1994-BR), SG_UE (2014)."
-sigla_unidade_federativa,"Sigla da Unidade da Federação em que ocorreu a eleição. Aparece no TSE como: SIGLA_UF (1994-BR), SG_UF (2014)."
+codigo_eleicao,Código da eleição. Aparece no TSE como: CD_ELEICAO (1996). Coluna adicionada em 1996.
+codigo_tipo_eleicao,Código do tipo de eleição. Aparece no TSE como: CD_TIPO_ELEICAO (1996). Coluna adicionada em 1996.
+data_eleicao,Data em que ocorreu a eleição. Aparece no TSE como: DT_ELEICAO (1996). Coluna adicionada em 1996.
+eleicao,"Descrição da eleição. Aparece no TSE como: DESCRICAO_ELEICAO (1994-BR), DS_ELEICAO (1996)."
+tipo_abrangencia_eleicao,Tipo de abrangência da eleição. Aparece no TSE como: TP_ABRANGENCIA (1996). Coluna adicionada em 1996.
+tipo_eleicao,Nome do tipo de eleição. Aparece no TSE como: NM_TIPO_ELEICAO (1996). Coluna adicionada em 1996.
+codigo_totalizacao_turno,"Código da situação de totalização do candidato naquele turno. Aparece no TSE como: COD_SIT_TOT_TURNO (1994-BR), CD_SIT_TOT_TURNO (1996)."
+totalizacao_turno,"Descrição da situação de totalização do candidato naquele turno. Aparece no TSE como: DESC_SIT_TOT_TURNO (1994-BR), DS_SIT_TOT_TURNO (1996)."
+turno,"Número do turno. Aparece no TSE como: NUM_TURNO (1994-BR), NR_TURNO (1996)."
+sigla_unidade_eleitoral,"Sigla da Unidade Eleitoral (Em caso de eleição majoritária é a sigla da UF que o candidato concorre (texto) e em caso de eleição municipal é o código TSE do município (número)). Assume os valores especiais BR, ZZ e VT para designar, respectivamente, o Brasil, Exterior e Voto em Trânsito. Aparece no TSE como: SIGLA_UE (1994-BR), SG_UE (1996)."
+sigla_unidade_federativa,"Sigla da Unidade da Federação em que ocorreu a eleição. Aparece no TSE como: SIGLA_UF (1994-BR), SG_UF (1996)."
 ano,Ano da eleição. Aparece no TSE como: ANO_ELEICAO (1994-BR).
-codigo_estado_civil,"Código do estado civil do candidato. Aparece no TSE como: CODIGO_ESTADO_CIVIL (1994-BR), CD_ESTADO_CIVIL (2014)."
-codigo_etnia,Código da etnia (cor/raça) do candidato (auto declaração). Aparece no TSE como: CD_COR_RACA (2014). Coluna adicionada em 2014.
-codigo_genero,"Código do sexo do candidato. Aparece no TSE como: CODIGO_SEXO (1994-BR), CD_GENERO (2014)."
-codigo_grau_instrucao,"Código do grau de instrução do candidato. Gerado internamente pelos sistemas eleitorais. Aparece no TSE como: COD_GRAU_INSTRUCAO (1994-BR), CD_GRAU_INSTRUCAO (2014)."
-codigo_municipio_nascimento,"Código TSE do município da nascimento do candidato. Aparece no TSE como: CODIGO_MUNICIPIO_NASCIMENTO (1994-BR), CD_MUNICIPIO_NASCIMENTO (2014)."
-codigo_nacionalidade,"Código da nacionalidade do candidato. Aparece no TSE como: CODIGO_NACIONALIDADE (1994-BR), CD_NACIONALIDADE (2014)."
-codigo_ocupacao,"Código da ocupação do candidato. Aparece no TSE como: CODIGO_OCUPACAO (1994-BR), CD_OCUPACAO (2014)."
-cpf,"CPF do candidato. Aparece no TSE como: CPF_CANDIDATO (1994-BR), NR_CPF_CANDIDATO (2014)."
-data_nascimento,"Data de nascimento do candidato. Aparece no TSE como: DATA_NASCIMENTO (1994-BR), DT_NASCIMENTO (2014)."
-email,E-mail para comunicação com o candidato. Aparece no TSE como: NM_EMAIL (2012). Coluna adicionada em 2012.
-estado_civil,"Descrição do estado civil do candidato. Aparece no TSE como: DESCRICAO_ESTADO_CIVIL (1994-BR), DS_ESTADO_CIVIL (2014)."
-etnia,Etnia (cor/raça) do candidato (auto declaração). Aparece no TSE como: DS_COR_RACA (2014). Coluna adicionada em 2014.
-genero,"Descrição do sexo do candidato. Aparece no TSE como: DESCRICAO_SEXO (1994-BR), DS_GENERO (2014)."
-grau_instrucao,"Descrição do grau de instrução do candidato. Aparece no TSE como: DESCRICAO_GRAU_INSTRUCAO (1994-BR), DS_GRAU_INSTRUCAO (2014)."
-municipio_nascimento,"Nome do município de nascimento do candidato. Aparece no TSE como: NOME_MUNICIPIO_NASCIMENTO (1994-BR), NM_MUNICIPIO_NASCIMENTO (2014)."
-nacionalidade,"Descrição da nacionalidade do candidato. Aparece no TSE como: DESCRICAO_NACIONALIDADE (1994-BR), DS_NACIONALIDADE (2014)."
-nome,"Nome completo do candidato. Aparece no TSE como: NOME_CANDIDATO (1994-BR), NM_CANDIDATO (2014)."
-nome_social,Nome social do candidato. Aparece no TSE como: NM_SOCIAL_CANDIDATO (2014). Coluna adicionada em 2014.
-ocupacao,"Descrição da ocupação do candidato. Aparece no TSE como: DESCRICAO_OCUPACAO (1994-BR), DS_OCUPACAO (2014)."
-sigla_unidade_federativa_nascimento,"Sigla da UF de nascimento do candidato. Aparece no TSE como: SIGLA_UF_NASCIMENTO (1994-BR), SG_UF_NASCIMENTO (2014)."
-titulo_eleitoral,"Número do título eleitoral do candidato. Aparece no TSE como: NUM_TITULO_ELEITORAL_CANDIDATO (1994-BR), NR_TITULO_ELEITORAL_CANDIDATO (2014)."
-unidade_eleitoral,"Descrição da Unidade Eleitoral. Aparece no TSE como: DESCRICAO_UE (1994-BR), NM_UE (2014)."
-codigo_legenda,"Código sequencial da legenda gerado pela Justiça Eleitoral. Aparece no TSE como: CODIGO_LEGENDA (1994-BR), SQ_COLIGACAO (2014)."
-composicao_legenda,"Composição da legenda. Aparece no TSE como: COMPOSICAO_LEGENDA (1994-BR), DS_COMPOSICAO_COLIGACAO (2014)."
-legenda,"Nome da legenda. Aparece no TSE como: NOME_LEGENDA (1994-BR), NM_COLIGACAO (2014)."
-numero_partido,"Número do partido. Aparece no TSE como: NUMERO_PARTIDO (1994-BR), NR_PARTIDO (2014)."
-partido,"Nome do partido. Aparece no TSE como: NOME_PARTIDO (1994-BR), NM_PARTIDO (2014)."
+codigo_estado_civil,"Código do estado civil do candidato. Aparece no TSE como: CODIGO_ESTADO_CIVIL (1994-BR), CD_ESTADO_CIVIL (1996)."
+codigo_etnia,Código da etnia (cor/raça) do candidato (auto declaração). Aparece no TSE como: CD_COR_RACA (1996). Coluna adicionada em 1996.
+codigo_genero,"Código do sexo do candidato. Aparece no TSE como: CODIGO_SEXO (1994-BR), CD_GENERO (1996)."
+codigo_grau_instrucao,"Código do grau de instrução do candidato. Gerado internamente pelos sistemas eleitorais. Aparece no TSE como: COD_GRAU_INSTRUCAO (1994-BR), CD_GRAU_INSTRUCAO (1996)."
+codigo_municipio_nascimento,"Código TSE do município da nascimento do candidato. Aparece no TSE como: CODIGO_MUNICIPIO_NASCIMENTO (1994-BR), CD_MUNICIPIO_NASCIMENTO (1996)."
+codigo_nacionalidade,"Código da nacionalidade do candidato. Aparece no TSE como: CODIGO_NACIONALIDADE (1994-BR), CD_NACIONALIDADE (1996)."
+codigo_ocupacao,"Código da ocupação do candidato. Aparece no TSE como: CODIGO_OCUPACAO (1994-BR), CD_OCUPACAO (1996)."
+cpf,"CPF do candidato. Aparece no TSE como: CPF_CANDIDATO (1994-BR), NR_CPF_CANDIDATO (1996)."
+data_nascimento,"Data de nascimento do candidato. Aparece no TSE como: DATA_NASCIMENTO (1994-BR), DT_NASCIMENTO (1996)."
+email,Endereço de e-mail do candidato. Aparece no TSE como: NM_EMAIL (1996). Coluna adicionada em 1996.
+estado_civil,"Descrição do estado civil do candidato. Aparece no TSE como: DESCRICAO_ESTADO_CIVIL (1994-BR), DS_ESTADO_CIVIL (1996)."
+etnia,Etnia (cor/raça) do candidato (auto declaração). Aparece no TSE como: DS_COR_RACA (1996). Coluna adicionada em 1996.
+genero,"Descrição do sexo do candidato. Aparece no TSE como: DESCRICAO_SEXO (1994-BR), DS_GENERO (1996)."
+grau_instrucao,"Descrição do grau de instrução do candidato. Aparece no TSE como: DESCRICAO_GRAU_INSTRUCAO (1994-BR), DS_GRAU_INSTRUCAO (1996)."
+municipio_nascimento,"Nome do município de nascimento do candidato. Aparece no TSE como: NOME_MUNICIPIO_NASCIMENTO (1994-BR), NM_MUNICIPIO_NASCIMENTO (1996)."
+nacionalidade,"Descrição da nacionalidade do candidato. Aparece no TSE como: DESCRICAO_NACIONALIDADE (1994-BR), DS_NACIONALIDADE (1996)."
+nome,"Nome completo do candidato. Aparece no TSE como: NOME_CANDIDATO (1994-BR), NM_CANDIDATO (1996)."
+nome_social,Nome social do candidato. Aparece no TSE como: NM_SOCIAL_CANDIDATO (1996). Coluna adicionada em 1996.
+ocupacao,"Descrição da ocupação do candidato. Aparece no TSE como: DESCRICAO_OCUPACAO (1994-BR), DS_OCUPACAO (1996)."
+sigla_unidade_federativa_nascimento,"Sigla da UF de nascimento do candidato. Aparece no TSE como: SIGLA_UF_NASCIMENTO (1994-BR), SG_UF_NASCIMENTO (1996)."
+titulo_eleitoral,"Número do título eleitoral do candidato. Aparece no TSE como: NUM_TITULO_ELEITORAL_CANDIDATO (1994-BR), NR_TITULO_ELEITORAL_CANDIDATO (1996)."
+unidade_eleitoral,"Descrição da Unidade Eleitoral. Aparece no TSE como: DESCRICAO_UE (1994-BR), NM_UE (1996)."
+codigo_legenda,"Código sequencial da legenda gerado pela Justiça Eleitoral. Aparece no TSE como: CODIGO_LEGENDA (1994-BR), SQ_COLIGACAO (1996)."
+composicao_legenda,"Composição da legenda. Aparece no TSE como: COMPOSICAO_LEGENDA (1994-BR), DS_COMPOSICAO_COLIGACAO (1996)."
+legenda,"Nome da legenda. Aparece no TSE como: NOME_LEGENDA (1994-BR), NM_COLIGACAO (1996)."
+numero_partido,"Número do partido. Aparece no TSE como: NUMERO_PARTIDO (1994-BR), NR_PARTIDO (1996)."
+partido,"Nome do partido. Aparece no TSE como: NOME_PARTIDO (1994-BR), NM_PARTIDO (1996)."
 sigla_legenda,Sigla da legenda. Aparece no TSE como: SIGLA_LEGENDA (1994-BR).
-sigla_partido,"Sigla do partido. Aparece no TSE como: SIGLA_PARTIDO (1994-BR), SG_PARTIDO (2014)."
-tipo_agremiacao,Tipo de agremiação - pode assumir os valores “coligação” (quando o candidato concorre por coligação) e “partido isolado” (quando o candidato concorre somente pelo partido). Aparece no TSE como: TP_AGREMIACAO (2014). Coluna adicionada em 2014.
-candidatura_inserida_urna,. Aparece no TSE como: ST_CANDIDATO_INSERIDO_URNA (2020). Coluna adicionada em 2020.
-cargo,"Descrição do cargo a que o candidato concorre. Aparece no TSE como: DESCRICAO_CARGO (1994-BR), DS_CARGO (2014)."
-codigo_cargo,"Código do cargo a que o candidato concorre. Aparece no TSE como: CODIGO_CARGO (1994-BR), CD_CARGO (2014)."
-codigo_detalhe_situacao_candidatura,Código do detalhe da situação do registro de candidatura do candidato. Aparece no TSE como: CD_DETALHE_SITUACAO_CAND (2014). Coluna adicionada em 2014.
-codigo_situacao_candidatura,"Código da situação de candidatura. Aparece no TSE como: COD_SITUACAO_CANDIDATURA (1994-BR), CD_SITUACAO_CANDIDATURA (2014)."
-codigo_situacao_candidatura_pleito,. Aparece no TSE como: CD_SITUACAO_CANDIDATO_PLEITO (2020). Coluna adicionada em 2020.
-codigo_situacao_candidatura_urna,. Aparece no TSE como: CD_SITUACAO_CANDIDATO_URNA (2020). Coluna adicionada em 2020.
-concorre_reeleicao,"O indicativo de que o candidato está concorrendo ou não à reeleição - pode assumir os valores “S” (sim) e “N” (não) -apenas para os cargos de presidente, governador e prefeito é possível candidatura à reeleição. Aparece no TSE como: ST_REELEICAO (2014). Coluna adicionada em 2014."
-declara_bens,O indicativo de que o candidato tem ou não bens a declarar - pode assumiar os valores “S” (em caso positivo) e “N” (em caso negativo). Aparece no TSE como: ST_DECLARAR_BENS (2014). Coluna adicionada em 2014.
-despesa_maxima_campanha,"Despesa máxima de campanha declarada pelo partido para aquele cargo. Valores em Reais.. Aparece no TSE como: DESPESA_MAX_CAMPANHA (1994-BR), NR_DESPESA_MAX_CAMPANHA (2014), VR_DESPESA_MAX_CAMPANHA (2020)."
-detalhe_situacao_candidatura,Descrição do detalhe da situação do registro de candidatura do candidato. Aparece no TSE como: DS_DETALHE_SITUACAO_CAND (2014). Coluna adicionada em 2014.
+sigla_partido,"Sigla do partido. Aparece no TSE como: SIGLA_PARTIDO (1994-BR), SG_PARTIDO (1996)."
+tipo_agremiacao,Tipo de agremiação - pode assumir os valores “coligação” (quando o candidato concorre por coligação) e “partido isolado” (quando o candidato concorre somente pelo partido). Aparece no TSE como: TP_AGREMIACAO (1996). Coluna adicionada em 1996.
+candidatura_inserida_urna,. Aparece no TSE como: ST_CANDIDATO_INSERIDO_URNA (1996). Coluna adicionada em 1996.
+cargo,"Descrição do cargo a que o candidato concorre. Aparece no TSE como: DESCRICAO_CARGO (1994-BR), DS_CARGO (1996)."
+codigo_cargo,"Código do cargo a que o candidato concorre. Aparece no TSE como: CODIGO_CARGO (1994-BR), CD_CARGO (1996)."
+codigo_detalhe_situacao_candidatura,Código do detalhe da situação do registro de candidatura do candidato. Aparece no TSE como: CD_DETALHE_SITUACAO_CAND (1996). Coluna adicionada em 1996.
+codigo_situacao_candidatura,"Código da situação de candidatura. Aparece no TSE como: COD_SITUACAO_CANDIDATURA (1994-BR), CD_SITUACAO_CANDIDATURA (1996)."
+codigo_situacao_candidatura_pleito,. Aparece no TSE como: CD_SITUACAO_CANDIDATO_PLEITO (1996). Coluna adicionada em 1996.
+codigo_situacao_candidatura_urna,. Aparece no TSE como: CD_SITUACAO_CANDIDATO_URNA (1996). Coluna adicionada em 1996.
+concorre_reeleicao,"O indicativo de que o candidato está concorrendo ou não à reeleição - pode assumir os valores “S” (sim) e “N” (não) -apenas para os cargos de presidente, governador e prefeito é possível candidatura à reeleição. Aparece no TSE como: ST_REELEICAO (1996). Coluna adicionada em 1996."
+declara_bens,O indicativo de que o candidato tem ou não bens a declarar - pode assumiar os valores “S” (em caso positivo) e “N” (em caso negativo). Aparece no TSE como: ST_DECLARAR_BENS (1996). Coluna adicionada em 1996.
+despesa_maxima_campanha,"Despesa máxima de campanha declarada pelo partido para aquele cargo. Valores em Reais.. Aparece no TSE como: DESPESA_MAX_CAMPANHA (1994-BR), VR_DESPESA_MAX_CAMPANHA (1996)."
+detalhe_situacao_candidatura,Descrição do detalhe da situação do registro de candidatura do candidato. Aparece no TSE como: DS_DETALHE_SITUACAO_CAND (1996). Coluna adicionada em 1996.
 idade_data_eleicao,Idade do candidato da data da eleição. Aparece no TSE como: IDADE_DATA_ELEICAO (1994-BR).
-idade_data_posse,Idade do candidato na data da posse (consultar a data de posse para cada cargo e unidade eleitoral nos arquivos de vagas). Aparece no TSE como: NR_IDADE_DATA_POSSE (2014). Coluna adicionada em 2014.
-nome_urna,"Nome de urna do candidato. Aparece no TSE como: NOME_URNA_CANDIDATO (1994-BR), NM_URNA_CANDIDATO (2014)."
-numero_processo_candidatura,Número do processo de registro de candidatura do candidato. Aparece no TSE como: NR_PROCESSO (2014). Coluna adicionada em 2014.
-numero_protocolo_candidatura,Número do protocolo de registro de candidatura do candidato. Aparece no TSE como: NR_PROTOCOLO_CANDIDATURA (2014). Coluna adicionada em 2014.
-numero_sequencial,"Número sequencial do candidato gerado internamente pelos sistemas eleitorais. Não é o número de campanha do candidato.. Aparece no TSE como: SEQUENCIAL_CANDIDATO (1994-BR), SQ_CANDIDATO (2014)."
-numero_urna,"Número do candidato na urna. Aparece no TSE como: NUMERO_CANDIDATO (1994-BR), NR_CANDIDATO (2014)."
-situacao_candidatura,"Descrição da situação de candidatura. Aparece no TSE como: DES_SITUACAO_CANDIDATURA (1994-BR), DS_SITUACAO_CANDIDATURA (2014)."
-situacao_candidatura_pleito,. Aparece no TSE como: DS_SITUACAO_CANDIDATO_PLEITO (2020). Coluna adicionada em 2020.
-situacao_candidatura_urna,. Aparece no TSE como: DS_SITUACAO_CANDIDATO_URNA (2020). Coluna adicionada em 2020.
+idade_data_posse,Idade do candidato na data da posse (consultar a data de posse para cada cargo e unidade eleitoral nos arquivos de vagas). Aparece no TSE como: NR_IDADE_DATA_POSSE (1996). Coluna adicionada em 1996.
+nome_urna,"Nome de urna do candidato. Aparece no TSE como: NOME_URNA_CANDIDATO (1994-BR), NM_URNA_CANDIDATO (1996)."
+numero_processo_candidatura,Número do processo de registro de candidatura do candidato. Aparece no TSE como: NR_PROCESSO (1996). Coluna adicionada em 1996.
+numero_protocolo_candidatura,Número do protocolo de registro de candidatura do candidato. Aparece no TSE como: NR_PROTOCOLO_CANDIDATURA (1996). Coluna adicionada em 1996.
+numero_sequencial,"Número sequencial do candidato gerado internamente pelos sistemas eleitorais. Não é o número de campanha do candidato.. Aparece no TSE como: SEQUENCIAL_CANDIDATO (1994-BR), SQ_CANDIDATO (1996)."
+numero_urna,"Número do candidato na urna. Aparece no TSE como: NUMERO_CANDIDATO (1994-BR), NR_CANDIDATO (1996)."
+situacao_candidatura,"Descrição da situação de candidatura. Aparece no TSE como: DES_SITUACAO_CANDIDATURA (1994-BR), DS_SITUACAO_CANDIDATURA (1996)."
+situacao_candidatura_pleito,. Aparece no TSE como: DS_SITUACAO_CANDIDATO_PLEITO (1996). Coluna adicionada em 1996.
+situacao_candidatura_urna,. Aparece no TSE como: DS_SITUACAO_CANDIDATO_URNA (1996). Coluna adicionada em 1996.


### PR DESCRIPTION
Rodei hoje os comandos `time python tse.py candidatura` e `time python tse.py bem-declarado` e em ambos houveram alguns problemas com os headers dos datasets de anos passados. 

Aparentemente as colunas dos datasets antigos foram padronizadas com as dos datasets recentes e com isso o mapeamento dos headers antigos estava quebrando o script (pois tentava acessar colunas que não existem mais).
Esse PR altera os mapeamentos para que o script consiga rodar corretamente. Basicamente:
- [x] Copiei o conteúdo de `headers/bem-declarado-2014.csv` (que era o último atualizado) para `headers/bem-declarado-2006.csv` (`headers/bem-declarado-final.csv` foi autogerado)
- [x] Copiei o conteúdo de `headers/candidatura-2020.csv` (que era o último atualizado) para `headers/candidatura-1996.csv`, `headers/candidatura-2012.csv ` e `headers/candidatura-2014.csv` (`headers/candidatura-final.csv` foi autogerado)

>👆 PS: Isso foi o suficiente para o script rodar sem erros. Como todos os arquivos acabaram que ficaram iguais eu fiquei em dúvida se seria melhor deletar os mapeamentos redundantes ou se eu deixava assim... Se o melhor procedimento for deletar os headers repetidos é só comentar que posso fazer isso nesse PR.

Além disso esse PR:
- [x] Ajusta a função que limpa as linhas do dataset para considerar `#NE` como sujeira (antes considerava apenas `#NE#`, mas aparentemente esse padrão mudou e então o script quebrava por não saber como lidar com `#NE`).
- [x] Remove alguns imports não usados em scripts 💅  