### PR TITLE
[Fix] Ajuste no extractor de receita para os arquivos de 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ conversões dos dados, como:
 
 - Retirar todos os acentos: alguns nomes aparecem com acentos em um ano e sem
   em outros, dificultando muito os agrupamentos;
-- Retirar strings inúteis: valores como `#NULO#`, `#NULO` e `#NE#` são
+- Retirar strings inúteis: valores como `#NULO#`, `#NULO`, `#NE` e `#NE#` são
   retirados, deixando as células em branco;
 - Normalização dos códigos de cargo: os códigos de cargo variam para alguns
   anos, tornando difícil o agrupamento entre anos e, para facilitar as

--- a/extractors.py
+++ b/extractors.py
@@ -184,10 +184,10 @@ def get_organization(internal_filename, year):
             return internal_filename.split("Receitas")[1].replace(".txt", "").lower()
         else:
             return internal_filename.split("Despesas")[1].replace(".txt", "").lower()
-    elif year in (2008, 2014, 2016):
+    elif year in (2014, 2016):
         return internal_filename.split("_")[1]
-    elif year in (2002, 2004, 2006):
-        return "comites" if "Comit" in internal_filename else "candidatos"
+    elif year in (2002, 2004, 2006, 2008):
+        return "comites" if "comit" in internal_filename.lower() else "candidatos"
     elif year == 2012:
         return internal_filename.split("_")[1]
     elif "2018" in year:

--- a/extractors.py
+++ b/extractors.py
@@ -798,7 +798,7 @@ class PrestacaoContasReceitasExtractor(PrestacaoContasExtractor):
             new = {}
             for key in final_field_names:
                 value = row.get(key, "").strip()
-                if value in ("#NULO", "#NULO#", "#NE#"):
+                if value in ("#NULO", "#NULO#", "#NE#", "#NE"):
                     value = ""
                 new[key] = value = utils.unaccent(value).upper()
 
@@ -828,7 +828,7 @@ class PrestacaoContasDespesasExtractor(PrestacaoContasExtractor):
             new = {}
             for key in final_field_names:
                 value = row.get(key, "").strip()
-                if value in ("#NULO", "#NULO#", "#NE#"):
+                if value in ("#NULO", "#NULO#", "#NE#", "#NE"):
                     value = ""
                 new[key] = value = utils.unaccent(value).upper()
 

--- a/extractors.py
+++ b/extractors.py
@@ -802,7 +802,8 @@ class PrestacaoContasReceitasExtractor(PrestacaoContasExtractor):
                     value = ""
                 new[key] = value = utils.unaccent(value).upper()
 
-            new["ano"] = year
+            cleaned_year, *_unused_suffix = str(year).split('-')
+            new["ano"] = int(cleaned_year)
             new["valor"] = fix_valor(new["valor"])
             new["data"] = fix_data(new["data"])
             new["data_prestacao_contas"] = fix_data(new["data_prestacao_contas"])
@@ -832,7 +833,8 @@ class PrestacaoContasDespesasExtractor(PrestacaoContasExtractor):
                     value = ""
                 new[key] = value = utils.unaccent(value).upper()
 
-            new["ano"] = year  # TODO: replace "2018-candidatos" with "2018"
+            cleaned_year, *_unused_suffix = str(year).split('-')
+            new["ano"] = int(cleaned_year)
             new["valor"] = fix_valor(new["valor"])
             new["data"] = fix_data(new["data"])
             new["data_prestacao_contas"] = fix_data(new["data_prestacao_contas"])


### PR DESCRIPTION
### Contexto
Ao rodar o comando `python tse.py receita` houveram alguns problemas com o ano de 2018 pois os headers dos arquivos não estavam sendo encontrados.
Acho que rolou uma mudança no padrão de nomeação dos arquivos de 2018 vindos do tse e isso fazia com que a função `get_organization` não conseguisse mapear corretamente a organização referente a esses arquivos. 

### Esse PR:
- [x] Ajusta o mapeamento de valores `null` para os extractors derivados de `PrestacaoContasExtractor` (aparentemente um novo padrão está sendo usado pelo tse)
- [x] Ajusta a função `get_organization` para identificar corretamente a organização de todos os anos
- [x] Resolve um `todo` no código para limpar os dados de "ano" das tabelas de prestação de contas e garantir que sempre sejam números, como esperado.